### PR TITLE
feat: Send both success and failure HTTP status codes to Uptime Kuma

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Ex:
 - Tag Name: "Method" / Tag Value: "GET"
 - Tag Name: "CertificateExpiration" / Tag Value: "7"
 - Tag Name: "IgnoreSSL" / Tag Value: "False"
+- Tag Name: "AllResults" / Tag Value: "False"
 
 ![image](https://github.com/zimbres/UptimeKumaRemoteProbe/assets/29772043/a4a9fd07-4f33-4f4f-9c27-24b59be42b28)
 
@@ -42,7 +43,9 @@ Ex:
 Available monitors type are:
 
 - Ping
-- Http, with or whithout Keyword. Tag Name "Keyword" must be applied to also check this
+- Http
+    - with or whithout Keyword. Tag Name "Keyword" must be applied to also check this
+    - When "AllResults" is True, both success and failure statuses are reported, by default set to False
 - Tcp
 - Certificate
 - Database

--- a/UptimeKumaRemoteProbe/Models/Configurations.cs
+++ b/UptimeKumaRemoteProbe/Models/Configurations.cs
@@ -18,6 +18,7 @@ public class Endpoint
 {
     public string Type { get; set; }
     public Uri PushUri { get; set; }
+    public Uri PushUri_http { get; set; }
     public string Destination { get; set; }
     public int Port { get; set; }
     public string Method { get; set; }

--- a/UptimeKumaRemoteProbe/Models/Configurations.cs
+++ b/UptimeKumaRemoteProbe/Models/Configurations.cs
@@ -18,7 +18,7 @@ public class Endpoint
 {
     public string Type { get; set; }
     public Uri PushUri { get; set; }
-    public Uri PushUri_http { get; set; }
+    public Uri BasePushUri { get; set; }
     public string Destination { get; set; }
     public int Port { get; set; }
     public string Method { get; set; }
@@ -29,6 +29,7 @@ public class Endpoint
     public string ConnectionString { get; set; }
     public string Brand { get; set; }
     public string Domain { get; set; }
+    public string AllResults { get; set; }
 }
 
 public class ConnectionStrings

--- a/UptimeKumaRemoteProbe/Models/Configurations.cs
+++ b/UptimeKumaRemoteProbe/Models/Configurations.cs
@@ -29,7 +29,7 @@ public class Endpoint
     public string ConnectionString { get; set; }
     public string Brand { get; set; }
     public string Domain { get; set; }
-    public string AllResults { get; set; }
+    public bool AllResults { get; set; }
 }
 
 public class ConnectionStrings

--- a/UptimeKumaRemoteProbe/Services/HttpService.cs
+++ b/UptimeKumaRemoteProbe/Services/HttpService.cs
@@ -44,10 +44,15 @@ public class HttpService
 
         if (result is not null )
         {
-            string status = result.StatusCode == HttpStatusCode.OK ? "up" : "down";
-            var pushUri_http = new Uri($"{endpoint.PushUri_http}status={status}&msg={result.StatusCode}&ping=");
-
-            await _pushService.PushAsync(PushUri_http, stopwatch.ElapsedMilliseconds);
+            if (endpoint.AllResults && !result.IsSuccessStatusCode)
+            {
+                var pushUri = new Uri($"{endpoint.BasePushUri}status=down&msg={result.StatusCode}&ping=");
+                await _pushService.PushAsync(pushUri, stopwatch.ElapsedMilliseconds);
+            }
+            else if (result.IsSuccessStatusCode)
+            {
+                await _pushService.PushAsync(endpoint.PushUri, stopwatch.ElapsedMilliseconds);
+            }
         }
     }
 }

--- a/UptimeKumaRemoteProbe/Services/HttpService.cs
+++ b/UptimeKumaRemoteProbe/Services/HttpService.cs
@@ -1,4 +1,5 @@
 ﻿namespace UptimeKumaRemoteProbe.Services;
+using System.Net;
 
 public class HttpService
 {
@@ -43,7 +44,7 @@ public class HttpService
 
         if (result is not null )
         {
-            string status = result.StatusCode == "OK" ? "up" : "down";
+            string status = result.StatusCode == HttpStatusCode.OK ? "up" : "down";
             var pushUri_http = new Uri($"{endpoint.PushUri_http}status={status}&msg={result.StatusCode}&ping=");
 
             await _pushService.PushAsync(PushUri_http, stopwatch.ElapsedMilliseconds);

--- a/UptimeKumaRemoteProbe/Services/HttpService.cs
+++ b/UptimeKumaRemoteProbe/Services/HttpService.cs
@@ -41,9 +41,12 @@ public class HttpService
             return;
         }
 
-        if (result is not null && result.IsSuccessStatusCode)
+        if (result is not null )
         {
-            await _pushService.PushAsync(endpoint.PushUri, stopwatch.ElapsedMilliseconds);
+            string status = result.StatusCode == "OK" ? "up" : "down";
+            var pushUri_http = new Uri($"{endpoint.PushUri_http}status={status}&msg={result.StatusCode}&ping=");
+
+            await _pushService.PushAsync(PushUri_http, stopwatch.ElapsedMilliseconds);
         }
     }
 }

--- a/UptimeKumaRemoteProbe/Worker.cs
+++ b/UptimeKumaRemoteProbe/Worker.cs
@@ -111,7 +111,7 @@ public class Worker : BackgroundService
                     Domain = monitor.Tags.Where(w => w.Name == "Domain").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     CertificateExpiration = int.Parse(monitor.Tags.Where(w => w.Name == "CertificateExpiration").Select(s => s.Value).FirstOrDefault() ?? "3"),
                     IgnoreSSL = bool.Parse(monitor.Tags.Where(w => w.Name == "IgnoreSSL").Select(s => s.Value).FirstOrDefault() ?? "False"),
-                    AllResults = = bool.Parse(monitor.Tags.Where(w => w.Name == "AllResults").Select(s => s.Value).FirstOrDefault() ?? "False")
+                    AllResults = bool.Parse(monitor.Tags.Where(w => w.Name == "AllResults").Select(s => s.Value).FirstOrDefault() ?? "False")
                 };
                 endpoints.Add(endpoint);
             }

--- a/UptimeKumaRemoteProbe/Worker.cs
+++ b/UptimeKumaRemoteProbe/Worker.cs
@@ -103,7 +103,7 @@ public class Worker : BackgroundService
                     Destination = monitor.Tags.Where(w => w.Name == "Address").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     Timeout = 1000,
                     PushUri = new Uri($"{_appSettings.Url}api/push/{monitor.PushToken}?status=up&msg=OK&ping="),
-                    PushUri_http = = new Uri($"{_appSettings.Url}api/push/{monitor.PushToken}?"),
+                    PushUri_http = new Uri($"{_appSettings.Url}api/push/{monitor.PushToken}?"),
                     Keyword = monitor.Tags.Where(w => w.Name == "Keyword").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     Method = monitor.Tags.Where(w => w.Name == "Method").Select(s => s.Value).FirstOrDefault(),
                     Brand = monitor.Tags.Where(w => w.Name == "Brand").Select(s => s.Value).FirstOrDefault() ?? string.Empty,

--- a/UptimeKumaRemoteProbe/Worker.cs
+++ b/UptimeKumaRemoteProbe/Worker.cs
@@ -103,7 +103,7 @@ public class Worker : BackgroundService
                     Destination = monitor.Tags.Where(w => w.Name == "Address").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     Timeout = 1000,
                     PushUri = new Uri($"{_appSettings.Url}api/push/{monitor.PushToken}?status=up&msg=OK&ping="),
-                    PushUri_http = new Uri($"{_appSettings.Url}api/push/{monitor.PushToken}?"),
+                    BasePushUri = new Uri($"{_appSettings.Url}api/push/{monitor.PushToken}?"),
                     Keyword = monitor.Tags.Where(w => w.Name == "Keyword").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     Method = monitor.Tags.Where(w => w.Name == "Method").Select(s => s.Value).FirstOrDefault(),
                     Brand = monitor.Tags.Where(w => w.Name == "Brand").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
@@ -111,6 +111,7 @@ public class Worker : BackgroundService
                     Domain = monitor.Tags.Where(w => w.Name == "Domain").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     CertificateExpiration = int.Parse(monitor.Tags.Where(w => w.Name == "CertificateExpiration").Select(s => s.Value).FirstOrDefault() ?? "3"),
                     IgnoreSSL = bool.Parse(monitor.Tags.Where(w => w.Name == "IgnoreSSL").Select(s => s.Value).FirstOrDefault() ?? "False")
+                    AllResults = = bool.Parse(monitor.Tags.Where(w => w.Name == "AllResults").Select(s => s.Value).FirstOrDefault() ?? "False")
                 };
                 endpoints.Add(endpoint);
             }

--- a/UptimeKumaRemoteProbe/Worker.cs
+++ b/UptimeKumaRemoteProbe/Worker.cs
@@ -110,7 +110,7 @@ public class Worker : BackgroundService
                     Port = int.Parse(monitor.Tags.Where(w => w.Name == "Port").Select(s => s.Value).FirstOrDefault() ?? "0"),
                     Domain = monitor.Tags.Where(w => w.Name == "Domain").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     CertificateExpiration = int.Parse(monitor.Tags.Where(w => w.Name == "CertificateExpiration").Select(s => s.Value).FirstOrDefault() ?? "3"),
-                    IgnoreSSL = bool.Parse(monitor.Tags.Where(w => w.Name == "IgnoreSSL").Select(s => s.Value).FirstOrDefault() ?? "False")
+                    IgnoreSSL = bool.Parse(monitor.Tags.Where(w => w.Name == "IgnoreSSL").Select(s => s.Value).FirstOrDefault() ?? "False"),
                     AllResults = = bool.Parse(monitor.Tags.Where(w => w.Name == "AllResults").Select(s => s.Value).FirstOrDefault() ?? "False")
                 };
                 endpoints.Add(endpoint);

--- a/UptimeKumaRemoteProbe/Worker.cs
+++ b/UptimeKumaRemoteProbe/Worker.cs
@@ -103,6 +103,7 @@ public class Worker : BackgroundService
                     Destination = monitor.Tags.Where(w => w.Name == "Address").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     Timeout = 1000,
                     PushUri = new Uri($"{_appSettings.Url}api/push/{monitor.PushToken}?status=up&msg=OK&ping="),
+                    PushUri_http = = new Uri($"{_appSettings.Url}api/push/{monitor.PushToken}?"),
                     Keyword = monitor.Tags.Where(w => w.Name == "Keyword").Select(s => s.Value).FirstOrDefault() ?? string.Empty,
                     Method = monitor.Tags.Where(w => w.Name == "Method").Select(s => s.Value).FirstOrDefault(),
                     Brand = monitor.Tags.Where(w => w.Name == "Brand").Select(s => s.Value).FirstOrDefault() ?? string.Empty,


### PR DESCRIPTION
## Description
Added a new AllResults option that allows more control over HTTP status reporting. When enabled, it reports both success and failure statuses to Uptime Kuma.

## Changes
- Added AllResults property to Endpoint model
- Modified HTTP service logic to handle AllResults flag
- Updated README with AllResults documentation
- Optimized URI construction for status reporting

## Testing
- Tested with AllResults=true: confirms both up/down statuses are reported
- Tested with AllResults=false: confirms only success statuses are reported
- Verified URI construction for different status scenarios

## Related Issue
Fixes #9 